### PR TITLE
Fixed typo of double curly braces 

### DIFF
--- a/components/summon_details.jsx
+++ b/components/summon_details.jsx
@@ -12,7 +12,7 @@ export function SummonDetails(props) {
                 <Text>Badge Number: {props.BadgeNumber}</Text>
                 <Text>Group Number: {props.GroupNumber}</Text>
                 <Text>Reporting Location: {props.ReportingLocation}</Text>
-                {(props.CanPostpone) ? <Postpone { ...{props}} /> : (<div><Text weight="bold">Cannot Postpone</Text></div>)}
+                {(props.CanPostpone) ? <Postpone { ...props} /> : (<div><Text weight="bold">Cannot Postpone</Text></div>)}
             </Container>
         </Container>
     )


### PR DESCRIPTION
typo causes props to be unable to be passed down to postpone component